### PR TITLE
Corrections to view projects in old versions of impasse and create plans of tests with the same name on different versions.

### DIFF
--- a/app/models/impasse/test_plan.rb
+++ b/app/models/impasse/test_plan.rb
@@ -14,21 +14,21 @@ module Impasse
 
     acts_as_customizable
 
-    def self.get_statistics_for_plan(version, plan)
-      total = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN(SELECT id FROM impasse_test_plans WHERE name = '#{plan}' AND version_id = ((SELECT id FROM versions WHERE name = '#{version}'))))"]
-      ok = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE status = '1' AND test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN(SELECT id FROM impasse_test_plans WHERE name = '#{plan}' AND version_id = ((SELECT id FROM versions WHERE name = '#{version}'))))"]
-      nog = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE status = '2' AND test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN(SELECT id FROM impasse_test_plans WHERE name = '#{plan}' AND version_id = ((SELECT id FROM versions WHERE name = '#{version}'))))"]
-      block = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE status = '3' AND test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN(SELECT id FROM impasse_test_plans WHERE name = '#{plan}' AND version_id = ((SELECT id FROM versions WHERE name = '#{version}'))))"]
+    def self.get_statistics_for_plan(version, plan, project)
+      total = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN(SELECT id FROM impasse_test_plans WHERE name = '#{plan}' AND version_id = ((SELECT id FROM versions WHERE name = '#{version}' AND project_id = #{project}))))"]
+      ok = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE status = '1' AND test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN(SELECT id FROM impasse_test_plans WHERE name = '#{plan}' AND version_id = ((SELECT id FROM versions WHERE name = '#{version}' AND project_id = #{project}))))"]
+      nog = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE status = '2' AND test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN(SELECT id FROM impasse_test_plans WHERE name = '#{plan}' AND version_id = ((SELECT id FROM versions WHERE name = '#{version}' AND project_id = #{project}))))"]
+      block = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE status = '3' AND test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN(SELECT id FROM impasse_test_plans WHERE name = '#{plan}' AND version_id = ((SELECT id FROM versions WHERE name = '#{version}' AND project_id = #{project}))))"]
       nok = nog+block
       undone = total-nok-ok
       [total,ok,nog,block,undone]
     end
     
-    def self.get_statistics(version)
-      total = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN (SELECT id FROM impasse_test_plans WHERE version_id IN (SELECT id FROM versions WHERE name = '#{version}')))"]
-      ok = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE status = '1' AND test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN (SELECT id FROM impasse_test_plans WHERE version_id IN (SELECT id FROM versions WHERE name = '#{version}')))"]
-      nog = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE status = '2' AND test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN (SELECT id FROM impasse_test_plans WHERE version_id IN (SELECT id FROM versions WHERE name = '#{version}')))"]
-      block = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE status = '3' AND test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN (SELECT id FROM impasse_test_plans WHERE version_id IN (SELECT id FROM versions WHERE name = '#{version}')))"]
+    def self.get_statistics(version, project)
+      total = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN (SELECT id FROM impasse_test_plans WHERE version_id IN (SELECT id FROM versions WHERE name = '#{version}' AND project_id = #{project})))"]
+      ok = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE status = '1' AND test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN (SELECT id FROM impasse_test_plans WHERE version_id IN (SELECT id FROM versions WHERE name = '#{version}' AND project_id = #{project})))"]
+      nog = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE status = '2' AND test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN (SELECT id FROM impasse_test_plans WHERE version_id IN (SELECT id FROM versions WHERE name = '#{version}' AND project_id = #{project})))"]
+      block = count_by_sql ["SELECT count(status) FROM impasse_executions WHERE status = '3' AND test_plan_case_id IN (SELECT id FROM impasse_test_plan_cases WHERE test_plan_id IN (SELECT id FROM impasse_test_plans WHERE version_id IN (SELECT id FROM versions WHERE name = '#{version}' AND project_id = #{project})))"]
       nok = nog+block
       undone = total-nok-ok
       [total,ok,nog,block,undone]

--- a/app/views/impasse_test_case/index.html.erb
+++ b/app/views/impasse_test_case/index.html.erb
@@ -145,11 +145,11 @@
     <tr><td class="td_tr_plans"></td><td class="td_tr_plans"><img src="/plugin_assets/redmine_impasse/stylesheets/images/book-brown.png" alt="Total" /></td><td class="td_tr_plans"><img src="/plugin_assets/redmine_impasse/stylesheets/images/tick.png" alt="OK" /></td><td class="td_tr_plans"><img src="/plugin_assets/redmine_impasse/stylesheets/images/cross.png" alt="Failed" /></td><td class="td_tr_plans"><img src="/plugin_assets/redmine_impasse/stylesheets/images/wall-brick.png" alt="In process" /></td><td class="td_tr_plans"><img src="/plugin_assets/redmine_impasse/stylesheets/images/document-attribute-t.png" alt="No run" /></td></tr>
       <% plans[version].each do |test_plan| %>
     <tr>
-  <% total, ok, fail, proc, undone = Impasse::TestPlan.get_statistics_for_plan(version.name,test_plan.name)  %>
+  <% total, ok, fail, proc, undone = Impasse::TestPlan.get_statistics_for_plan(version.name,test_plan.name, version.project_id)  %>
   <td class="td_tr_plans" style="text-align:left;"><%= link_to test_plan.name, :controller=>:impasse_test_plans, :action=>:show, :project_id=>@project, :id=>test_plan%></td><td class="td_tr_plans"><strong><%= total%></strong></td><td class="td_tr_plans"><%= ok%></td><td class="td_tr_plans"><%= fail%></td><td class="td_tr_plans"><%= proc%></td><td class="td_tr_plans"><%= undone%></td>
     </tr>  
     <% end %>
-    <% total, ok, fail, proc, undone = Impasse::TestPlan.get_statistics(version.name)  %>
+    <% total, ok, fail, proc, undone = Impasse::TestPlan.get_statistics(version.name, version.project_id)  %>
     <tr><td class="td_tr_plans" style="text-align:left;"><strong>Total</strong></td><td class="td_tr_plans"><strong><%= total%></strong></td><td class="td_tr_plans"><strong><%= ok%></strong></td><td class="td_tr_plans"><strong><%= fail%></strong></td><td class="td_tr_plans"><strong><%= proc%></strong></td><td class="td_tr_plans"><strong><%= undone%></strong></tr>
     </table>
   <hr style="margin-top:10px;margin-bottom:10px;"/>


### PR DESCRIPTION
Log:
- Re-added params "project" to functions "get_statistics_for_plan" and "get_statistics"
- Re-added params "project" where these functions are called.
- Added on query of these functions above the condition "AND project_id = project"

This small bug fix was necessary to correct two problems. They are:
- To view the statistics on the page "plans of tests" for old versions of redmine_impasse.
- Fix the error correlated with "plans of tests" with the same name, but in different projects. With this, we can copy plans of tests to different projects and keep them with the same name.
