### PR TITLE
Fixes statistics NoMethodError on Heroku

### DIFF
--- a/app/models/impasse/statistics.rb
+++ b/app/models/impasse/statistics.rb
@@ -6,7 +6,7 @@ module Impasse
 
     def self.summary_default(test_plan_id, test_suite_id=nil)
       conditions = { :test_plan_id => test_plan_id }
-      concatinated_path = case configurations[Rails.env]['adapter']
+      concatinated_path = case Rails.configuration.database_configuration['adapter']
                           when /mysql/
                             "CONCAT(:path, head.id, '.')"
                           when /sqlserver/


### PR DESCRIPTION
"configurations" Hash object seems empty on Heroku which leads to a `NoMethodError (undefined method `[]' for nil:NilClass)` error.

Here is the full error log:

```
2015-06-24T13:38:16.917630+00:00 app[web.1]: Started GET "/projects/project1/impasse/test_plans/statistics/3" for 31.32.122.211 at 2015-06-24 13:38:16 +0000
2015-06-24T13:38:16.936961+00:00 app[web.1]: DEPRECATION WARNING: Calling set_table_name is deprecated. Please use `self.table_name = 'the_name'` instead. (called from <class:Statistics> at /app/plugins/redmine_impasse/app/models/impasse/statistics.rb:4)
2015-06-24T13:38:16.940624+00:00 app[web.1]:
2015-06-24T13:38:16.940628+00:00 app[web.1]: NoMethodError (undefined method `[]' for nil:NilClass):
2015-06-24T13:38:16.940630+00:00 app[web.1]:   plugins/redmine_impasse/app/models/impasse/statistics.rb:9:in `summary_default'
2015-06-24T13:38:16.940631+00:00 app[web.1]:   plugins/redmine_impasse/app/controllers/impasse_test_plans_controller.rb:93:in `statistics'
2015-06-24T13:38:16.940634+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_controller/metal/implicit_render.rb:4:in `send_action'
2015-06-24T13:38:16.940636+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/abstract_controller/base.rb:167:in `process_action'
2015-06-24T13:38:16.940637+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_controller/metal/rendering.rb:10:in `process_action'
2015-06-24T13:38:16.940639+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/abstract_controller/callbacks.rb:18:in `block in process_action'
2015-06-24T13:38:16.940641+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:469:in `_run__4367329879686286192__process_action__1720104512291509582__callbacks'
2015-06-24T13:38:16.940642+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:405:in `__run_callback'
2015-06-24T13:38:16.940644+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:385:in `_run_process_action_callbacks'
2015-06-24T13:38:16.940645+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:81:in `run_callbacks'
2015-06-24T13:38:16.940646+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/abstract_controller/callbacks.rb:17:in `process_action'
2015-06-24T13:38:16.940648+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_controller/metal/rescue.rb:29:in `process_action'
2015-06-24T13:38:16.940650+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_controller/metal/instrumentation.rb:30:in `block in process_action'
2015-06-24T13:38:16.940651+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/notifications.rb:123:in `block in instrument'
2015-06-24T13:38:16.940652+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
2015-06-24T13:38:16.940653+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/notifications.rb:123:in `instrument'
2015-06-24T13:38:16.940655+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_controller/metal/instrumentation.rb:29:in `process_action'
2015-06-24T13:38:16.940657+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.13/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
2015-06-24T13:38:16.940656+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_controller/metal/params_wrapper.rb:207:in `process_action'
2015-06-24T13:38:16.940658+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/abstract_controller/base.rb:121:in `process'
2015-06-24T13:38:16.940660+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/abstract_controller/rendering.rb:45:in `process'
2015-06-24T13:38:16.940661+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_controller/metal.rb:203:in `dispatch'
2015-06-24T13:38:16.940662+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_controller/metal/rack_delegation.rb:14:in `dispatch'
2015-06-24T13:38:16.940663+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_controller/metal.rb:246:in `block in action'
2015-06-24T13:38:16.940666+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/routing/route_set.rb:73:in `dispatch'
2015-06-24T13:38:16.940665+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/routing/route_set.rb:73:in `call'
2015-06-24T13:38:16.940667+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/routing/route_set.rb:36:in `call'
2015-06-24T13:38:16.940668+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/journey-1.0.4/lib/journey/router.rb:68:in `block in call'
2015-06-24T13:38:16.940670+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/journey-1.0.4/lib/journey/router.rb:56:in `each'
2015-06-24T13:38:16.940672+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/routing/route_set.rb:612:in `call'
2015-06-24T13:38:16.940671+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/journey-1.0.4/lib/journey/router.rb:56:in `call'
2015-06-24T13:38:16.940674+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/rack-openid-1.4.2/lib/rack/openid.rb:98:in `call'
2015-06-24T13:38:16.940676+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/etag.rb:23:in `call'
2015-06-24T13:38:16.940675+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/middleware/best_standards_support.rb:17:in `call'
2015-06-24T13:38:16.940678+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/conditionalget.rb:25:in `call'
2015-06-24T13:38:16.940679+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/middleware/head.rb:14:in `call'
2015-06-24T13:38:16.940680+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/middleware/params_parser.rb:21:in `call'
2015-06-24T13:38:16.940810+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/middleware/flash.rb:242:in `call'
2015-06-24T13:38:16.940812+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/session/abstract/id.rb:210:in `context'
2015-06-24T13:38:16.940813+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/session/abstract/id.rb:205:in `call'
2015-06-24T13:38:16.940815+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.13/lib/active_record/query_cache.rb:64:in `call'
2015-06-24T13:38:16.940817+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activerecord-3.2.13/lib/active_record/connection_adapters/abstract/connection_pool.rb:479:in `call'
2015-06-24T13:38:16.940814+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/middleware/cookies.rb:341:in `call'
2015-06-24T13:38:16.940818+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
2015-06-24T13:38:16.940821+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:405:in `_run__3465509216146240955__call__3586415205756604819__callbacks'
2015-06-24T13:38:16.940822+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:405:in `__run_callback'
2015-06-24T13:38:16.940823+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:385:in `_run_call_callbacks'
2015-06-24T13:38:16.940825+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:81:in `run_callbacks'
2015-06-24T13:38:16.940826+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/middleware/callbacks.rb:27:in `call'
2015-06-24T13:38:16.940827+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/middleware/remote_ip.rb:31:in `call'
2015-06-24T13:38:16.940829+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/middleware/debug_exceptions.rb:16:in `call'
2015-06-24T13:38:16.940830+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/middleware/show_exceptions.rb:56:in `call'
2015-06-24T13:38:16.940832+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/railties-3.2.13/lib/rails/rack/logger.rb:32:in `call_app'
2015-06-24T13:38:16.940833+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/railties-3.2.13/lib/rails/rack/logger.rb:16:in `block in call'
2015-06-24T13:38:16.940834+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/tagged_logging.rb:22:in `tagged'
2015-06-24T13:38:16.940836+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/railties-3.2.13/lib/rails/rack/logger.rb:16:in `call'
2015-06-24T13:38:16.940837+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_dispatch/middleware/request_id.rb:22:in `call'
2015-06-24T13:38:16.940838+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/methodoverride.rb:21:in `call'
2015-06-24T13:38:16.940840+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/rack-1.4.7/lib/rack/runtime.rb:17:in `call'
2015-06-24T13:38:16.940841+00:00 app[web.1]:   vendor/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/cache/strategy/local_cache.rb:72:in `call'
```
